### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,18 @@ categories = ["multimedia"]
 version = "1.0.0"
 
 [dependencies]
-artnet_protocol = "0.4.1"
+artnet_protocol = "0.4.2"
 artnet_reciever = "0.3.0"
-eframe = "0.21.3"
-local-ip-address = "0.5.1"
-log = "0.4.17"
+eframe = "0.26.2"
+local-ip-address = "0.6.0"
+log = "0.4.20"
 log-panics = { version = "2.1.0" }
 open_dmx = "1.0.1"
 serial = "0.4.0"
-serialport = "4.2.0"
-simple_logger = "4.0.0"
-socket2 = { version = "0.5.1", features = ["all"] }
-image = "0.24.6"
+serialport = "4.3.0"
+simple_logger = "4.3.3"
+socket2 = { version = "0.5.6", features = ["all"] }
+image = "0.24.9"
 
 [build-dependencies]
-winres = "0.1.8"
+winres = "0.1.12"

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -240,9 +240,9 @@ impl eframe::App for App {
         };
         egui::CentralPanel::default().frame(panel_frame).show(ctx, |ui| {
             let app_rect = ui.max_rect();
-            // if ui.interact(app_rect, egui::Id::new("window"), egui::Sense::click()).is_pointer_button_down_on() {
-            //     ui.ctx().send_viewport_cmd(ViewportCommand::StartDrag);
-            // }
+            if ui.interact(app_rect, egui::Id::new("window"), egui::Sense::click()).is_pointer_button_down_on() {
+                ui.ctx().send_viewport_cmd(ViewportCommand::StartDrag);
+            }
 
             let title_bar_height = 32.0;
             let title_bar_rect = {

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -239,6 +239,9 @@ impl eframe::App for App {
             ..Default::default()
         };
         egui::CentralPanel::default().frame(panel_frame).show(ctx, |ui| {
+
+            ui.style_mut().interaction.selectable_labels = false;
+            
             let app_rect = ui.max_rect();
             if ui.interact(app_rect, egui::Id::new("window"), egui::Sense::click()).is_pointer_button_down_on() {
                 ui.ctx().send_viewport_cmd(ViewportCommand::StartDrag);


### PR DESCRIPTION
Update the dependencies.

Updating eframe past version 24 causes the application to stop working. This appears due to the "Error Overlay" intercepting the mouse events. Commenting it out allows the app to work as expected.

Could make the overlay opaque and add an ok button, maybe emulate a dialog box but wanted to get your thoughts before going down that route?